### PR TITLE
Print full error of 'git clone' instead of assuming that a remote isn't defined

### DIFF
--- a/scripts/clap
+++ b/scripts/clap
@@ -90,10 +90,12 @@ class Logger(object):
         print '{s:{c}^{n}}'.format(s=header, n=40, c='-')
 
     def log_multiline(self, repo, output):
+        first_line = True
         for line in output.split('\n'):
             if line:
                 line = Fore.YELLOW + line
-                self.log(repo, line)
+                self.log(repo if first_line else '', line)
+                first_line = False
 
     def log_status(self, line, repo):
         if not line:
@@ -285,8 +287,8 @@ def pull():
         git = Git(repo)
         try:
             output = git.pull()
-        except sh.ErrorReturnCode:
-            output = 'No upstream defined. Skipping pull.'
+        except sh.ErrorReturnCode as ex:
+            output = 'Pull failed: {}'.format(str(ex))
         logger.log_multiline(repo, output)
 
     logger.header('Pull')


### PR DESCRIPTION
Example output before:

```
-------------Pull-------------
cloudify-dev                  | Already up to date.
cloudify-fabric-plugin        | Already up to date.
docl                          | Already up to date.
cloudify-amqp-influxdb        | Already up to date.
cloudify-diamond-plugin       | Already up to date.
cloudify-common               | No upstream defined. Skipping pull.
cloudify-manager-install      | Already up to date.
cloudify-premium              | Already up to date.
cloudify-system-tests         | Already up to date.
cloudify-cli                  | Already up to date.
cloudify-agent                | Already up to date.
cloudify-manager              | No upstream defined. Skipping pull.
------Took 2.06 seconds-------
```

Example output now:

```
-------------Pull-------------
cloudify-dev                  | Already up to date.
docl                          | Already up to date.
cloudify-diamond-plugin       | Already up to date.
cloudify-amqp-influxdb        | Already up to date.
cloudify-fabric-plugin        | Already up to date.
cloudify-common               | Already up to date.
cloudify-manager-install      | Already up to date.
cloudify-premium              | Already up to date.
cloudify-system-tests         | Already up to date.
cloudify-agent                | Already up to date.
cloudify-cli                  | Already up to date.
cloudify-manager              | Pull failed:
                              |   RAN: '/usr/bin/git --no-pager --git-dir /home/whatever/dev/repos/cloudify-manager/.git --work-tree /home/whatever/dev/repos/cloudify-manager pull'
                              |   STDOUT:
                              |   STDERR:
                              | key_load_public: invalid format
                              | Your configuration specifies to merge with the ref 'refs/heads/CY-757'
                              | from the remote, but no such ref was fetched.
------Took 1.95 seconds-------
```